### PR TITLE
Fix README fine-tuning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,48 +283,10 @@ In the following scenario, the D2C-6.7B model effectively calls a class **IrisCl
 
 ### 5. How to Fine-tune D2C
 
-We provide script `finetune/finetune_d2c.py` for users to finetune our models on downstream tasks.
-
-The script supports the training with [DeepSpeed](https://github.com/microsoft/DeepSpeed). You need install required packages by:
-
-```bash
-pip install -r requirements-finetune.txt
-```
-
-Please follow [Sample Dataset Format](#) to prepare your training data.
-Each line is a json-serialized string with two required fields `instruction` and `output`.
-
-After data preparation, you can use the sample shell script to finetune `deepseek-ai/d2c-6.7b-instruct`. 
-Remember to specify `DATA_PATH`, `OUTPUT_PATH`.
-And please choose appropriate hyper-parameters(e.g., `learning_rate`, `per_device_train_batch_size`) according to your scenario.
-
-```bash
-DATA_PATH="<your_data_path>"
-OUTPUT_PATH="<your_output_path>"
-MODEL="deepseek-ai/d2c-6.7b-instruct"
-
-cd finetune && deepspeed finetune_d2c.py \
-    --model_name_or_path $MODEL_PATH \
-    --data_path $DATA_PATH \
-    --output_dir $OUTPUT_PATH \
-    --num_train_epochs 3 \
-    --model_max_length 1024 \
-    --per_device_train_batch_size 16 \
-    --per_device_eval_batch_size 1 \
-    --gradient_accumulation_steps 4 \
-    --evaluation_strategy "no" \
-    --save_strategy "steps" \
-    --save_steps 100 \
-    --save_total_limit 100 \
-    --learning_rate 2e-5 \
-    --warmup_steps 10 \
-    --logging_steps 1 \
-    --lr_scheduler_type "cosine" \
-    --gradient_checkpointing True \
-    --report_to "tensorboard" \
-    --deepspeed configs/ds_config_zero3.json \
-    --bf16 True
-```
+This repository does not provide an official fine-tuning script. You can
+create your own training pipeline using the dependencies listed in
+`requirements-finetune.txt`. Prepare your dataset as JSON lines containing
+the fields `instruction` and `output`.
 
 ### 6. Detailed Evaluation Results
 


### PR DESCRIPTION
## Summary
- remove references to the non-existent `finetune/finetune_d2c.py`
- mention that no official fine-tuning script is included

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68896bbdd5e0832984b95e075a55dace