### PR TITLE
Fix evaluation docs for local paths

### DIFF
--- a/Evaluation/HumanEval/README.md
+++ b/Evaluation/HumanEval/README.md
@@ -9,7 +9,6 @@ We provide a test script to evaluate the performance of the **d2c** model on cod
 ```
 pip install accelerate
 pip install attrdict
-pip install transformers
 pip install pytorch
 ```
 
@@ -21,7 +20,7 @@ We've created a sample script, **eval.sh**, that demonstrates how to test the **
 Additionally, for various programming languages, the execution path may differ. Please ensure you update the appropriate paths in the **humaneval/execution.py** file accordingly.
 
 ```bash
-MODEL_NAME_OR_PATH="deepseek-ai/d2c-1.3b-base"
+MODEL_NAME_OR_PATH="PATH_TO_LOCAL_MODEL"
 DATASET_ROOT="data/"
 LANGUAGE="python"
 python -m accelerate.commands.launch --config_file test_config.yaml eval_pal.py --logdir ${MODEL_NAME_OR_PATH} --language ${LANGUAGE} --dataroot ${DATASET_ROOT} 
@@ -31,10 +30,10 @@ To evaluate the instruction-based model, please follow the script below:
 ```bash
 LANG="python"
 OUPUT_DIR="output"
-MODEL="d2c-33b-instruct"
+MODEL="PATH_TO_LOCAL_MODEL"
 
 CUDA_VISIBLE_DEVICES=0,1 python eval_instruct.py \
-    --model "deepseek-ai/$MODEL" \
+    --model "$MODEL" \
     --output_path "$OUPUT_DIR/${LANG}.$MODEL.jsonl" \
     --language $LANG \
     --temp_dir $OUPUT_DIR

--- a/Evaluation/HumanEval/eval.sh
+++ b/Evaluation/HumanEval/eval.sh
@@ -1,4 +1,5 @@
-MODEL_NAME_OR_PATH="deepseek-ai/d2c-1.3b-base"
+#!/bin/bash
+MODEL_NAME_OR_PATH="PATH_TO_LOCAL_MODEL"
 DATASET_ROOT="data/"
 LANGUAGE="python"
 CUDA_VISIBLE_DEVICES=1,2,3 python -m accelerate.commands.launch --config_file test_config.yaml eval_pal.py --logdir ${MODEL_NAME_OR_PATH} --language ${LANGUAGE} --dataroot ${DATASET_ROOT}

--- a/Evaluation/LeetCode/readme.md
+++ b/Evaluation/LeetCode/readme.md
@@ -10,7 +10,7 @@ Please follow the following two steps to evaluate the model's performance on our
 cd Evaluation/LeetCode
 
 # Set the model or path here
-MODEL="deepseek-ai/d2c-7b-instruct"
+MODEL="PATH_TO_LOCAL_MODEL"
 
 python vllm_inference.py --model_name_or_path $MODEL --saved_path output/20240121-Jul.d2c-7b-instruct.jsonl
 ```

--- a/Evaluation/MBPP/README.md
+++ b/Evaluation/MBPP/README.md
@@ -9,7 +9,6 @@ We provide a test script to evaluate the performance of the **d2c** model on cod
 ```
 pip install accelerate
 pip install attrdict
-pip install transformers
 pip install pytorch
 ```
 
@@ -20,7 +19,7 @@ pip install pytorch
 We've created a sample script, **eval.sh**, that demonstrates how to test the **d2c-1.3b-base** model on the MBPP dataset leveraging **8** GPUs.
 
 ```bash
-MODEL_NAME_OR_PATH="deepseek-ai/d2c-1.3b-base"
+MODEL_NAME_OR_PATH="PATH_TO_LOCAL_MODEL"
 DATASET_ROOT="data/"
 LANGUAGE="python"
 python -m accelerate.commands.launch --config_file test_config.yaml eval_pal.py --logdir ${MODEL_NAME_OR_PATH} --dataroot ${DATASET_ROOT} 

--- a/Evaluation/MBPP/eval.sh
+++ b/Evaluation/MBPP/eval.sh
@@ -1,4 +1,5 @@
-MODEL_NAME_OR_PATH="deepseek-ai/d2c-1.3b-base"
+#!/bin/bash
+MODEL_NAME_OR_PATH="PATH_TO_LOCAL_MODEL"
 DATASET_ROOT="data/"
 LANGUAGE="python"
 CUDA_VISIBLE_DEVICES=1,2,3 python -m accelerate.commands.launch --config_file test_config.yaml eval_pal.py --logdir ${MODEL_NAME_OR_PATH} --language ${LANGUAGE} --dataroot ${DATASET_ROOT}

--- a/Evaluation/PAL-Math/README.md
+++ b/Evaluation/PAL-Math/README.md
@@ -7,7 +7,7 @@ We provide a test script to evaluate the capability of the **d2c** model to solv
 ## 2. Setup
 
 ```
-pip install sympy==1.12 pebble timeout-decorator transformers
+pip install sympy==1.12 pebble timeout-decorator
 ```
 
 
@@ -17,7 +17,7 @@ pip install sympy==1.12 pebble timeout-decorator transformers
 We provide an example of testing the **d2c-1.3b-base** model on the **gsm8k** dataset using **8** GPUs. If you wish to use a different model or dataset, you can modify it as needed.
 
 ```bash
-MODEL_NAME_OR_PATH=deepseek-ai/d2c-1.3b-base
+MODEL_NAME_OR_PATH=PATH_TO_LOCAL_MODEL
 DATA=gsm8k # 'math' 'gsm8k' 'gsm-hard' 'svamp' 'tabmwp' 'asdiv' 'mawps'
 MODEL_DIR_NAME=${MODEL_NAME_OR_PATH##*/}
 GPU_NUM=8


### PR DESCRIPTION
## Summary
- stop recommending transformers install for evaluation
- use `PATH_TO_LOCAL_MODEL` in evaluation docs
- fix evaluation shell scripts

## Testing
- `shellcheck Evaluation/HumanEval/eval.sh Evaluation/MBPP/eval.sh`

------
https://chatgpt.com/codex/tasks/task_e_68896c58500883299837c6c078f0fa7e